### PR TITLE
Consolidate ip calls

### DIFF
--- a/dnsbls_bypass.php
+++ b/dnsbls_bypass.php
@@ -44,10 +44,11 @@ if ($requestMethod === "POST"){
   ]));
 
   if ($resp === '1') {
-    $tor = checkDNSBL($_SERVER['REMOTE_ADDR']);
+    $tor = checkDNSBL($_SERVER['REMOTE_ADDR']); // This actually needs to use an IP address, but doesnt store it anywhere
+    $identity = getIdentity();
     if (!$tor) {
       $query = prepare('INSERT INTO ``dnsbl_bypass`` VALUES(:ip, NOW(), 0) ON DUPLICATE KEY UPDATE `created`=NOW(),`uses`=0');
-      $query->bindValue(':ip', $_SERVER['REMOTE_ADDR']);
+      $query->bindValue(':ip', $identity);
       $query->execute() or error(db_error($query));
     }
     $cookie = bin2hex(openssl_random_pseudo_bytes(16));

--- a/inc/filters.php
+++ b/inc/filters.php
@@ -5,6 +5,7 @@
  */
 
 defined('TINYBOARD') or exit;
+require_once 'inc/functions.php';
 
 class Filter {
 	public $flood_check;
@@ -38,7 +39,8 @@ class Filter {
 					foreach ($match as $flood_match_arg) {
 						switch ($flood_match_arg) {
 							case 'ip':
-								if ($flood_post['ip'] != $_SERVER['REMOTE_ADDR'])
+								$identity = getIdentity();
+								if ($flood_post['ip'] != $identity)
 									continue 3;
 								break;
 							case 'body':
@@ -117,7 +119,8 @@ class Filter {
 				}
 				return false;
 			case 'ip':
-				return preg_match($match, $_SERVER['REMOTE_ADDR']);
+				$identity = getIdentity();
+				return preg_match($match, $identity);
 			case 'op':
 				return $post['op'] == $match;
 			case 'has_file':
@@ -135,9 +138,10 @@ class Filter {
 		global $board;
 
 		$this->add_note = isset($this->add_note) ? $this->add_note : false;
+		$identity = getIdentity();
 		if ($this->add_note) {
 			$query = prepare('INSERT INTO ``ip_notes`` VALUES (NULL, :ip, :mod, :time, :body)');
-	                $query->bindValue(':ip', $_SERVER['REMOTE_ADDR']);
+	                $query->bindValue(':ip', $identity);
         	        $query->bindValue(':mod', -1);
 	                $query->bindValue(':time', time());
 	                $query->bindValue(':body', "Autoban message: ".$this->post['body']);
@@ -147,6 +151,7 @@ class Filter {
 			case 'reject':
 				error(isset($this->message) ? $this->message : 'Posting throttled by filter.');
 			case 'ban':
+				$identity = getIdentity();
 				if (!isset($this->reason))
 					error('The ban action requires a reason.');
 				
@@ -154,7 +159,7 @@ class Filter {
 				$this->reject = isset($this->reject) ? $this->reject : true;
 				$this->all_boards = isset($this->all_boards) ? $this->all_boards : false;
 				
-				Bans::new_ban($_SERVER['REMOTE_ADDR'], $this->reason, $this->expires, $this->all_boards ? false : $board['uri'], -1);
+				Bans::new_ban($identity, $this->reason, $this->expires, $this->all_boards ? false : $board['uri'], -1);
 
 				if ($this->reject) {
 					if (isset($this->message))
@@ -222,13 +227,15 @@ function do_filters(array $post) {
 	
 	if (isset($has_flood)) {
 		if ($post['has_file']) {
+			$identity = getIdentity();
 			$query = prepare("SELECT * FROM ``flood`` WHERE `ip` = :ip OR `posthash` = :posthash OR `filehash` = :filehash");
-			$query->bindValue(':ip', $_SERVER['REMOTE_ADDR']);
+			$query->bindValue(':ip', $identity);
 			$query->bindValue(':posthash', make_comment_hex($post['body_nomarkup']));
 			$query->bindValue(':filehash', $post['filehash']);
 		} else {
+			$identity = getIdentity();
 			$query = prepare("SELECT * FROM ``flood`` WHERE `ip` = :ip OR `posthash` = :posthash");
-			$query->bindValue(':ip', $_SERVER['REMOTE_ADDR']);
+			$query->bindValue(':ip', $identity);
 			$query->bindValue(':posthash', make_comment_hex($post['body_nomarkup']));
 		}
 		$query->execute() or error(db_error($query));

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -3061,3 +3061,8 @@ function markdown($s) {
 
 	return $pd->text($s);
 }
+
+function getIdentity(){
+  $identity = $_SERVER['REMOTE_ADDR'];
+  return $identity;
+}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -33,6 +33,11 @@ register_shutdown_function('fatal_error_handler');
 mb_internal_encoding('UTF-8');
 loadConfig();
 
+function getIdentity(){
+  $identity = $_SERVER['REMOTE_ADDR'];
+  return $identity;
+}
+
 function init_locale($locale, $error='error') {
 	if ($locale === 'en') 
 		$locale = 'en_US.utf8';
@@ -265,9 +270,11 @@ function loadConfig() {
 	}
 
 	// Keep the original address to properly comply with other board configurations
-	if (!isset($__ip))
-		$__ip = $_SERVER['REMOTE_ADDR'];
-
+	if (!isset($__ip)){
+		$identity = getIdentity();
+		$__ip = $identity;
+	}
+	
 	// ::ffff:0.0.0.0
 	if (preg_match('/^\:\:(ffff\:)?(\d+\.\d+\.\d+\.\d+)$/', $__ip, $m))
 		$_SERVER['REMOTE_ADDR'] = $m[2];
@@ -1035,8 +1042,9 @@ function displayBan($ban) {
 	if (!$ban['seen']) {
 		Bans::seen($ban['id']);
 	}
-
-	$ban['ip'] = $_SERVER['REMOTE_ADDR'];
+	$identity = getIdentity();
+	
+	$ban['ip'] = $identity;
 
 	if ($ban['post'] && isset($ban['post']['board'], $ban['post']['id'])) {
 		if (openBoard($ban['post']['board'])) {
@@ -1095,8 +1103,9 @@ function checkBan($board = false) {
 
 	if (event('check-ban', $board))
 		return true;
-
-	$bans = Bans::find($_SERVER['REMOTE_ADDR'], $board, $config['show_modname']);
+	$identity = getIdentity();
+	
+	$bans = Bans::find($identity, $board, $config['show_modname']);
 	
 	foreach ($bans as &$ban) {
 		if ($ban['expires'] && $ban['expires'] < time()) {
@@ -1184,9 +1193,10 @@ function threadExists($id) {
 
 function insertFloodPost(array $post) {
 	global $board;
+	$identity = getIdentity();
 	
 	$query = prepare("INSERT INTO ``flood`` VALUES (NULL, :ip, :board, :time, :posthash, :filehash, :isreply)");
-	$query->bindValue(':ip', $_SERVER['REMOTE_ADDR']);
+	$query->bindValue(':ip', $identity);
 	$query->bindValue(':board', $board['uri']);
 	$query->bindValue(':time', time());
 	$query->bindValue(':posthash', make_comment_hex($post['body_nomarkup']));
@@ -1225,12 +1235,14 @@ function post(array $post) {
 		$query->bindValue(':trip', null, PDO::PARAM_NULL);
 	}
 	
+	$identity = getIdentity();
+	
 	$query->bindValue(':name', $post['name']);
 	$query->bindValue(':body', $post['body']);
 	$query->bindValue(':body_nomarkup', $post['body_nomarkup']);
 	$query->bindValue(':time', isset($post['time']) ? $post['time'] : time(), PDO::PARAM_INT);
 	$query->bindValue(':password', $post['password']);
-	$query->bindValue(':ip', isset($post['ip']) ? $post['ip'] : $_SERVER['REMOTE_ADDR']);
+	$query->bindValue(':ip', isset($post['ip']) ? $post['ip'] : $identity);
 	
 	if ($post['op'] && $post['mod'] && isset($post['sticky']) && $post['sticky']) {
 		$query->bindValue(':sticky', true, PDO::PARAM_INT);
@@ -1585,7 +1597,8 @@ function index($page, $mod=false) {
 
 // Handle statistic tracking for a new post.
 function updateStatisticsForPost( $post, $new = true ) {
-	$postIp   = isset($post['ip']) ? $post['ip'] : $_SERVER['REMOTE_ADDR'];
+	$identity = getIdentity();
+	$postIp   = isset($post['ip']) ? $post['ip'] : $identity;
 	$postUri  = $post['board'];
 	$postTime = (int)( $post['time'] / 3600 ) * 3600;
 	
@@ -1788,11 +1801,12 @@ function muteTime() {
 
 	if ($time = event('mute-time'))
 		return $time;
-
+	$identity = getIdentity();
+	
 	// Find number of mutes in the past X hours
 	$query = prepare("SELECT COUNT(*) FROM ``mutes`` WHERE `time` >= :time AND `ip` = :ip");
 	$query->bindValue(':time', time()-($config['robot_mute_hour']*3600), PDO::PARAM_INT);
-	$query->bindValue(':ip', $_SERVER['REMOTE_ADDR']);
+	$query->bindValue(':ip', $identity);
 	$query->execute() or error(db_error($query));
 
 	if (!$result = $query->fetchColumn())
@@ -1802,9 +1816,10 @@ function muteTime() {
 
 function mute() {
 	// Insert mute
+	$identity = getIdentity();
 	$query = prepare("INSERT INTO ``mutes`` VALUES (:ip, :time)");
 	$query->bindValue(':time', time(), PDO::PARAM_INT);
-	$query->bindValue(':ip', $_SERVER['REMOTE_ADDR']);
+	$query->bindValue(':ip', $identity);
 	$query->execute() or error(db_error($query));
 
 	return muteTime();
@@ -1814,17 +1829,19 @@ function checkMute() {
 	global $config;
 
 	if ($config['cache']['enabled']) {
+		$identity = getIdentity();
 		// Cached mute?
-		if (($mute = cache::get("mute_${_SERVER['REMOTE_ADDR']}")) && ($mutetime = cache::get("mutetime_${_SERVER['REMOTE_ADDR']}"))) {
+		if (($mute = cache::get("mute_${identity}")) && ($mutetime = cache::get("mutetime_${identity}"))) {
 			error(sprintf($config['error']['youaremuted'], $mute['time'] + $mutetime - time()));
 		}
 	}
 
 	$mutetime = muteTime();
 	if ($mutetime > 0) {
+		$identity = getIdentity();
 		// Find last mute time
 		$query = prepare("SELECT `time` FROM ``mutes`` WHERE `ip` = :ip ORDER BY `time` DESC LIMIT 1");
-		$query->bindValue(':ip', $_SERVER['REMOTE_ADDR']);
+		$query->bindValue(':ip', $identity);
 		$query->execute() or error(db_error($query));
 
 		if (!$mute = $query->fetch(PDO::FETCH_ASSOC)) {
@@ -1834,8 +1851,9 @@ function checkMute() {
 
 		if ($mute['time'] + $mutetime > time()) {
 			if ($config['cache']['enabled']) {
-				cache::set("mute_${_SERVER['REMOTE_ADDR']}", $mute, $mute['time'] + $mutetime - time());
-				cache::set("mutetime_${_SERVER['REMOTE_ADDR']}", $mutetime, $mute['time'] + $mutetime - time());
+				$identity = getIdentity();
+				cache::set("mute_${identity}", $mute, $mute['time'] + $mutetime - time());
+				cache::set("mutetime_${identity}", $mutetime, $mute['time'] + $mutetime - time());
 			}
 			// Not expired yet
 			error(sprintf($config['error']['youaremuted'], $mute['time'] + $mutetime - time()));
@@ -3060,9 +3078,4 @@ function markdown($s) {
 	$pd->setimagesEnabled(false);
 
 	return $pd->text($s);
-}
-
-function getIdentity(){
-  $identity = $_SERVER['REMOTE_ADDR'];
-  return $identity;
 }

--- a/inc/instance-functions.php
+++ b/inc/instance-functions.php
@@ -1,6 +1,7 @@
 <?php
 require_once("inc/8chan-functions.php");
 require_once("inc/8chan-mod-pages.php");
+require_once("inc/functions.php");
 
 require_once "lib/htmlpurifier-4.6.0/library/HTMLPurifier.auto.php";
 
@@ -10,8 +11,9 @@ function max_posts_per_hour($post) {
 	if (!$config['hour_max_threads']) return false;
 
 	if ($post['op']) {
+		$identity = getIdentity();
 		$query = prepare(sprintf('SELECT COUNT(*) AS `count` FROM ``posts_%s`` WHERE `thread` IS NULL AND FROM_UNIXTIME(`time`) > DATE_SUB(NOW(), INTERVAL 1 HOUR);', $board['uri']));
-		$query->bindValue(':ip', $_SERVER['REMOTE_ADDR']);
+		$query->bindValue(':ip', $identity);
 		$query->execute() or error(db_error($query));
 		$r = $query->fetch(PDO::FETCH_ASSOC);
 

--- a/inc/mod/auth.php
+++ b/inc/mod/auth.php
@@ -5,6 +5,7 @@
  */
 
 defined('TINYBOARD') or exit;
+require_once 'inc/functions.php';
 
 // create a hash/salt pair for validate logins
 function mkhash($username, $password, $salt = false) {
@@ -18,7 +19,8 @@ function mkhash($username, $password, $salt = false) {
 	}
 	
 	// generate hash (method is not important as long as it's strong)
-	$hash = substr(base64_encode(md5($username . $config['cookies']['salt'] . sha1($username . $password . $salt . ($config['mod']['lock_ip'] ? $_SERVER['REMOTE_ADDR'] : ''), true), true)), 0, 20);
+	$identity = getIdentity();
+	$hash = substr(base64_encode(md5($username . $config['cookies']['salt'] . sha1($username . $password . $salt . ($config['mod']['lock_ip'] ? $identity : ''), true), true)), 0, 20);
 	
 	if (isset($generated_salt))
 		return array($hash, $salt);
@@ -80,9 +82,10 @@ function destroyCookies() {
 
 function modLog($action, $_board=null) {
 	global $mod, $board, $config;
+	$identity = getIdentity();
 	$query = prepare("INSERT INTO ``modlogs`` VALUES (:id, :ip, :board, :time, :text)");
 	$query->bindValue(':id', (isset($mod['id']) ? $mod['id'] : -1), PDO::PARAM_INT);
-	$query->bindValue(':ip', $_SERVER['REMOTE_ADDR']);
+	$query->bindValue(':ip', $identity);
 	$query->bindValue(':time', time(), PDO::PARAM_INT);
 	$query->bindValue(':text', $action);
 	if (isset($_board))

--- a/post.php
+++ b/post.php
@@ -191,10 +191,11 @@ if (isset($_POST['delete'])) {
 						' for "' . $reason . '"'
 					);
 				}
+				$identity = getIdentity();
 				
 				$query = prepare("INSERT INTO `reports` (`time`, `ip`, `board`, `post`, `reason`, `local`, `global`) VALUES (:time, :ip, :board, :post, :reason, :local, :global)");
 				$query->bindValue(':time',   time(), PDO::PARAM_INT);
-				$query->bindValue(':ip',     $_SERVER['REMOTE_ADDR'], PDO::PARAM_STR);
+				$query->bindValue(':ip',     $identity, PDO::PARAM_STR);
 				$query->bindValue(':board',  $board['uri'], PDO::PARAM_INT);
 				$query->bindValue(':post',   $id, PDO::PARAM_INT);
 				$query->bindValue(':reason', $reason, PDO::PARAM_STR);
@@ -1080,8 +1081,8 @@ elseif (isset($_POST['appeal'])) {
 		error($config['error']['bot']);
 	
 	$ban_id = (int)$_POST['ban_id'];
-	
-	$bans = Bans::find($_SERVER['REMOTE_ADDR']);
+	$identity = getIdentity();
+	$bans = Bans::find($identity);
 	foreach ($bans as $_ban) {
 		if ($_ban['id'] == $ban_id) {
 			$ban = $_ban;

--- a/search.php
+++ b/search.php
@@ -20,9 +20,10 @@
 	if(isset($_GET['search']) && !empty($_GET['search']) && isset($_GET['board']) && in_array($_GET['board'], $boards)) {		
 		$phrase = $_GET['search'];
 		$_body = '';
+		$identity = getIdentity();
 		
 		$query = prepare("SELECT COUNT(*) FROM ``search_queries`` WHERE `ip` = :ip AND `time` > :time");
-		$query->bindValue(':ip', $_SERVER['REMOTE_ADDR']);
+		$query->bindValue(':ip', $identity);
 		$query->bindValue(':time', time() - ($queries_per_minutes[1] * 60));
 		$query->execute() or error(db_error($query));
 		if($query->fetchColumn() > $queries_per_minutes[0])
@@ -36,7 +37,7 @@
 			
 		
 		$query = prepare("INSERT INTO ``search_queries`` VALUES (:ip, :time, :query)");
-		$query->bindValue(':ip', $_SERVER['REMOTE_ADDR']);
+		$query->bindValue(':ip', $identity);
 		$query->bindValue(':time', time());
 		$query->bindValue(':query', $phrase);
 		$query->execute() or error(db_error($query));


### PR DESCRIPTION
This points all* `$_SERVER['REMOTE_ADDR']` calls to `getIdentity()`. The calls that this replaces were historically placed into the database under the `ip` column. After consolidating all the calls, our next step is to replace the `getIdentity()` function to return a HASH of an IP instead of the IP itself. This will then guarantee that no IP address is ever stored on the database.

\* Calls that are omitted are used to determine country flags, tor identification, ipv6 identification, etc. These calls should not be stored on database.