### PR TITLE
Add DOM class to post backlinks

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -2202,7 +2202,7 @@ function markup(&$body, $track_cites = false, $op = false) {
 			}
 
 			if (isset($cited_posts[$cite])) {
-				$replacement = '<a onclick="highlightReply(\''.$cite.'\', event);" href="' .
+				$replacement = '<a class="postBacklink" onclick="highlightReply(\''.$cite.'\', event);" href="' .
 					$config['root'] . $board['dir'] . $config['dir']['res'] .
 					($cited_posts[$cite] ? $cited_posts[$cite] : $cite) . '.html#' . $cite . '">' .
 					'&gt;&gt;' . $cite .
@@ -2302,7 +2302,7 @@ function markup(&$body, $track_cites = false, $op = false) {
 				if (isset($cited_posts[$_board][$cite])) {
 					$link = $cited_posts[$_board][$cite];
 					
-					$replacement = '<a ' .
+					$replacement = '<a class="postBacklink"' .
 						($_board == $board['uri'] ?
 							'onclick="highlightReply(\''.$cite.'\', event);" '
 						: '') . 'href="' . $link . '">' .


### PR DESCRIPTION
For backlinks `>>[postnumber]`, openIB currently formats links like so:

`<a onclick='highlightReply('POSTNUMBER', event);' href='/BOARD/res/THREAD.html#post>>>POSTNUMBER</a>`

It would be really helpful for js stuff if you could add an DOM class to these like so:

`<a class='postBacklink' onclick='highlightReply('POSTNUMBER', event);' href='/BOARD/res/THREAD.html#post>>>POSTNUMBER</a>`

As far as I can tell it's just editing two lines:
https://github.com/OpenIB/OpenIB/blob/master/inc/functions.php#L2205
https://github.com/OpenIB/OpenIB/blob/master/inc/functions.php#L2307