### PR TITLE
Shortened IP hashes to last eight characters on ban forms, board logs, ban messages and top of post histories.

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1076,7 +1076,11 @@ function displayBan($ban) {
 			}
 		}
 	}
-	
+
+	if(strpos($ban['ip'],'$2a$07$') !== false) {
+		$ban['ip'] = "...".substr($ban['ip'],-8);
+	}
+
 	// Show banned page and exit
 	die(
 		Element('page.html', array(


### PR DESCRIPTION
Shortened IP hashes on ban forms