### PR TITLE
Strip HTML, JS and PHP tags from Title / Subtitle fields on create.php and board settings

### DIFF
--- a/inc/8chan-mod-pages.php
+++ b/inc/8chan-mod-pages.php
@@ -506,8 +506,8 @@ FLAGS;
 			$txtboard = $board_type == 'txtboard';
 			$fileboard = $board_type == 'fileboard';
 
-			$title = $_POST['title'];
-			$subtitle = $_POST['subtitle'];
+			$title = strip_tags(scan_input($_POST['title'],'settings'));
+			$subtitle = strip_tags(scan_input($_POST['subtitle'],'settings'));
 			$country_flags = isset($_POST['country_flags']) ? 'true' : 'false';
 			$field_disable_name = isset($_POST['field_disable_name']) ? 'true' : 'false';
 			$force_anon_thread = isset($_POST['force_anon_thread']) ? 'true' : 'false';


### PR DESCRIPTION
Remove html , php tags and check if string has html and php tags