### PR TITLE
Fixed Board Owner permissions on boards

### DIFF
--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -129,6 +129,14 @@ function mod_dashboard() {
 	
 	modLog('Looked at dashboard', false);
 	
+    	if($mod['boards'][0]!="*"){
+      		foreach($args['boards'] as $boarddisplay){
+          		if(in_array($boarddisplay['uri'], $mod['boards'],true)){
+            			$args['displayboards'][] = $boarddisplay;
+          		}
+      		}
+    	}
+
 	mod_page(_('Dashboard'), 'mod/dashboard.html', $args);
 }
 


### PR DESCRIPTION
Fixed Board Owner permissions on boards whose names are exclusively comprised of 0 (0, 00, 000 etc.).