### PR TITLE
Fixed forced anonymous boardwide so all account types (BOs, BVs etc.)…

### DIFF
--- a/inc/8chan-mod-config.php
+++ b/inc/8chan-mod-config.php
@@ -33,7 +33,7 @@
 	$config['mod']['postinlocked'] = BOARDVOLUNTEER;
 	$config['mod']['bumplock'] = BOARDVOLUNTEER;
 	$config['mod']['view_bumplock'] = BOARDVOLUNTEER;
-	$config['mod']['bypass_field_disable'] = BOARDVOLUNTEER;
+	$config['mod']['bypass_field_disable'] = JANITOR;
 	$config['mod']['view_banlist'] = BOARDVOLUNTEER;
 	$config['mod']['view_banstaff'] = BOARDVOLUNTEER;
 	$config['mod']['public_ban'] = BOARDVOLUNTEER;


### PR DESCRIPTION
… are able to capcode when this option is enabled.

Fixed forced anonymous boardwide so all account types (BOs, BVs etc.) are able to capcode when this option is enabled.