### PR TITLE
create asset symlink on board creation

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -538,12 +538,13 @@ function setupBoard($array) {
 	$dir = 'static/assets/'. $board['uri'];	
 	if (!is_dir($dir))
 		mkdir($dir, 0777, true);
+	if (!file_exists ($dir . '/deleted.png'))
 		symlink(getcwd() . '/' . $config['image_deleted'], "$dir/deleted.png");
+	if (!file_exists ($dir . '/spoiler.png'))
 		symlink(getcwd() . '/' . $config['spoiler_image'], "$dir/spoiler.png");
+	if (!file_exists ($dir . '/no-file.png'))
 		symlink(getcwd() . '/' . $config['no_file_image'], "$dir/no-file.png");
-
-
-
+		
 }
 
 function openBoard($uri) {

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -534,6 +534,16 @@ function setupBoard($array) {
 	if (!file_exists($board['dir'] . $config['dir']['res']))
 		@mkdir($board['dir'] . $config['dir']['res'], 0777)
 			or error("Couldn't create " . $board['dir'] . $config['dir']['img'] . ". Check permissions.", true);
+	
+	$dir = 'static/assets/'. $board['uri'];	
+	if (!is_dir($dir))
+		mkdir($dir, 0777, true);
+		symlink(getcwd() . '/' . $config['image_deleted'], "$dir/deleted.png");
+		symlink(getcwd() . '/' . $config['spoiler_image'], "$dir/spoiler.png");
+		symlink(getcwd() . '/' . $config['no_file_image'], "$dir/no-file.png");
+
+
+
 }
 
 function openBoard($uri) {


### PR DESCRIPTION
prevents 404 if assets are never generated by visiting /assets and custom assets is enabled by BO.